### PR TITLE
Use env for shebang in examples

### DIFF
--- a/examples/checkin.py
+++ b/examples/checkin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -----------------------------------------------------------------------
 # Copyright (C) 2015 King County Library System
 # Bill Erickson <berickxx@gmail.com>

--- a/examples/checkout.py
+++ b/examples/checkout.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -----------------------------------------------------------------------
 # Copyright (C) 2015 King County Library System
 # Bill Erickson <berickxx@gmail.com>

--- a/examples/item-info-request.py
+++ b/examples/item-info-request.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -----------------------------------------------------------------------
 # Copyright (C) 2015 King County Library System
 # Bill Erickson <berickxx@gmail.com>

--- a/examples/patron-info-request-threaded.py
+++ b/examples/patron-info-request-threaded.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -----------------------------------------------------------------------
 # Copyright (C) 2015 King County Library System
 # Bill Erickson <berickxx@gmail.com>

--- a/examples/sc-status.py
+++ b/examples/sc-status.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -----------------------------------------------------------------------
 # Copyright (C) 2015 King County Library System
 # Bill Erickson <berickxx@gmail.com>


### PR DESCRIPTION
Use "/usr/bin/env python3" in the shebang of the example scripts,
rather than hardcoding "/usr/bin/python3".

Useful when python3 is in the path but not at /usr/bin/python3

Signed-off-by: Jeff Godin jgodin@tadl.org
